### PR TITLE
Add support for message/rfc822 body parts

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -171,6 +171,11 @@
 //!                    ],
 //!                ),
 //!                MimePart::new_text("Part K contents go here...").inline(),
+//!
+//!                // A whole RFC compliant e-mail message (including headers)
+//!                // can be attached using the MimePart::new_message method
+//!                // and by supplying the message as a bytes reference.
+//!                MimePart::new_message("Part L contents go here...".as_bytes()),
 //!            ],
 //!        ))
 //!        
@@ -564,6 +569,7 @@ mod tests {
                         ],
                     ),
                     MimePart::new_text("Part K contents go here...").inline(),
+                    MimePart::new_message("Part L contents go here...".as_bytes()),
                 ],
             ))
             .write_to_vec()


### PR DESCRIPTION
The existing Text and Binary body part types always ends up with a Content-Transfer-Encoding of base64, quoted-printable, or, in certain circumstances, 7bit. None of these are suitable for attaching a full e-mail message. RFC2046 states: "No encoding other than "7bit", "8bit", or "binary" is permitted for the body of a "message/rfc822" entity".

This patch adds support for a BodyPart::Message type, which will always be rendered with a Content-Transfer-Encoding of "binary".