### PR TITLE
fix incorrect new lines in headers

### DIFF
--- a/src/headers/text.rs
+++ b/src/headers/text.rs
@@ -11,13 +11,12 @@
 
 use std::borrow::Cow;
 
+use super::Header;
 use crate::encoders::{
     base64::base64_encode_mime,
     encode::{get_encoding_type, EncodingType},
     quoted_printable::quoted_printable_encode,
 };
-
-use super::Header;
 
 /// Unstructured text e-mail header.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
@@ -45,7 +44,7 @@ impl<'x> Header for Text<'x> {
     fn write_header(
         &self,
         mut output: impl std::io::Write,
-        mut bytes_written: usize,
+        bytes_written: usize,
     ) -> std::io::Result<usize> {
         match get_encoding_type(self.text.as_bytes(), true, false) {
             EncodingType::Base64 => {
@@ -73,15 +72,7 @@ impl<'x> Header for Text<'x> {
                 }
             }
             EncodingType::None => {
-                for (pos, &ch) in self.text.as_bytes().iter().enumerate() {
-                    if bytes_written >= 76 && ch.is_ascii_whitespace() && pos < self.text.len() - 1
-                    {
-                        output.write_all(b"\r\n\t")?;
-                        bytes_written = 1;
-                    }
-                    output.write_all(&[ch])?;
-                    bytes_written += 1;
-                }
+                output.write_all(self.text.as_bytes())?;
                 output.write_all(b"\r\n")?;
             }
         }


### PR DESCRIPTION
multiline header like Received

Received: Text("from 139-162-244-188.cprapid.com\n\tby 139-162-244-188.cprapid.com with LMTP\n\tid RQb5Ojfdd2O5LikAqCNTnA\n\t(envelope-from <pajkovsky@139-162-244-188.cprapid.com>)\n\tfor <pajkovsky@139-162-244-188.cprapid.com>; Fri, 18 Nov 2022 19:29:59 +0000")

was incorrectly rendered

   Received: from 139-162-244-188.cprapid.com
        by 139-162-244-188.cprapid.com with
         LMTP
        id RQb5Ojfdd2O5LikAqCNTnA
        (envelope-from <pajkovsky@139-162-244-188.cprapid.com>)

        for <pajkovsky@139-162-244-188.cprapid.com>; Fri, 18 Nov 2022 19:29:59 +0000

but the output

   Received: from 139-162-244-188.cprapid.com
        by 139-162-244-188.cprapid.com with LMTP
        id RQb5Ojfdd2O5LikAqCNTnA
        (envelope-from <pajkovsky@139-162-244-188.cprapid.com>)
        for <pajkovsky@139-162-244-188.cprapid.com>; Fri, 18 Nov 2022 19:29:59 +0000

The patch removes adding line folding for Text. Probably incorrect.