### PR TITLE
Fixed Multipart message adding multiple line breaks

### DIFF
--- a/src/mime.rs
+++ b/src/mime.rs
@@ -348,7 +348,6 @@ impl<'x> MimePart<'x> {
                             boundary = Some(boundary_.into());
                         }
 
-                        output.write_all(b"\r\n")?;
                         it = parts.into_iter();
                     }
                 }


### PR DESCRIPTION
Fix for line breaks in issue #14.

Since a multipart message will always have a boundary after it, there is no need to write a new line after the header.