### PR TITLE
Make gethostname an optional feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,11 +12,12 @@ categories = ["email"]
 readme = "README.md"
 
 [features]
-default = []
+default = ["gethostname"]
+gethostname = ["dep:gethostname"]
 ludicrous_mode = []
 
 [dependencies]
-gethostname = "0.4.0"
+gethostname = { version = "0.4.0", optional = true }
 
 [dev-dependencies]
 mail-parser = "0.9"

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ _mail-builder_ is a flexible **e-mail builder library** written in Rust. It incl
 - Full **MIME** support (_RFC 2045 - 2049_) with automatic selection of the most optimal encoding for each message body part.
 - **Fast Base64 encoding** based on Chromium's decoder ([the fastest non-SIMD encoder](https://github.com/lemire/fastbase64)).
 - Minimal dependencies.
+  - The dependency on `gethostname` is optional.
 
 Please note that this library does not support sending or parsing e-mail messages as these functionalities are provided by the crates [`mail-send`](https://crates.io/crates/mail-send) and [`mail-parser`](https://crates.io/crates/mail-parser).
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -410,10 +410,16 @@ impl<'x> MessageBuilder<'x> {
 
         if !has_message_id {
             output.write_all(b"Message-ID: ")?;
+
+            #[cfg(feature = "gethostname")]
             generate_message_id_header(
                 &mut output,
                 gethostname::gethostname().to_str().unwrap_or("localhost"),
             )?;
+
+            #[cfg(not(feature = "gethostname"))]
+            generate_message_id_header(&mut output, "localhost")?;
+
             output.write_all(b"\r\n")?;
         }
 

--- a/src/mime.rs
+++ b/src/mime.rs
@@ -108,7 +108,13 @@ thread_local!(static COUNTER: Cell<u64> = Cell::new(0));
 
 pub fn make_boundary(separator: &str) -> String {
     let mut s = DefaultHasher::new();
+
+    #[cfg(feature = "gethostname")]
     gethostname::gethostname().hash(&mut s);
+
+    #[cfg(not(feature = "gethostname"))]
+    "localhost".hash(&mut s);
+
     thread::current().id().hash(&mut s);
     let hash = s.finish();
 


### PR DESCRIPTION
Hi there @mdecimus! 

I am a happy user of several of your email crates, including mail-builder. I want to be able to use mail-builder without depending on `gethostname`. I propose making the dependency on `gethostname` optional, but enabled by default, so that existing users of this crate are not disrupted in any way.

This change has three benefits:

1. It reduces the size of the dependency graph.
2. `MessageBuilder` never blocks, so it's usable inside an async context.
3. My outputs become deterministic and aren't tied to the machine they're generated on. This is important for my tests in my network-jailed CI system.

While the usage of `#[cfg(...)]` inline is a bit awkward, I found it was the simplest way to achieve my goal. The alternatives were: 

1. Using a macro, which means you have to navigate elsewhere to see what the code is really doing.
2. Needlessly copying the `&str` returned by `gethostname`.