### PR TITLE
support wasm

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,7 +16,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - name: Install
+      run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
     - name: Build
       run: cargo build --verbose
     - name: Run tests
       run: cargo test --verbose
+    - name: Run wasm tests
+      run: wasm-pack test --node --no-default-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,14 @@ ludicrous_mode = []
 [dependencies]
 gethostname = { version = "0.4.0", optional = true }
 
+[target.'cfg(target_family = "wasm")'.dependencies]
+wasmtimer = { version = "0.2.0" }
+
 [dev-dependencies]
 mail-parser = "0.9"
-serde = { version = "1.0", features = ["derive"]}
+serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.9.10"
 serde_json = "1.0"
+
+[target.'cfg(target_family = "wasm")'.dev-dependencies]
+wasm-bindgen-test = "0.3"

--- a/src/headers/date.rs
+++ b/src/headers/date.rs
@@ -9,10 +9,12 @@
  * except according to those terms.
  */
 
-use std::{
-    io::{self, Write},
-    time::SystemTime,
-};
+use std::io::{self, Write};
+
+#[cfg(not(target_family="wasm"))]
+use std::time::SystemTime;
+#[cfg(target_family="wasm")]
+use wasmtimer::std::SystemTime;
 
 pub static DOW: &[&str] = &["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
 pub static MONTH: &[&str] = &[

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -501,7 +501,8 @@ mod tests {
         MessageBuilder,
     };
 
-    #[test]
+    #[cfg_attr(not(target_family = "wasm"), test)]
+    #[cfg_attr(target_family = "wasm", wasm_bindgen_test::wasm_bindgen_test)]
     fn build_nested_message() {
         let output = MessageBuilder::new()
             .from(Address::new_address("John Doe".into(), "john@doe.com"))
@@ -574,7 +575,8 @@ mod tests {
         //fs::write("test.yaml", &serde_yaml::to_string(&message).unwrap()).unwrap();
     }
 
-    #[test]
+    #[cfg_attr(not(target_family = "wasm"), test)]
+    #[cfg_attr(target_family = "wasm", wasm_bindgen_test::wasm_bindgen_test)]
     fn build_message() {
         let output = MessageBuilder::new()
             .from(("John Doe", "john@doe.com"))

--- a/src/mime.rs
+++ b/src/mime.rs
@@ -16,8 +16,13 @@ use std::{
     hash::{Hash, Hasher},
     io::{self, Write},
     thread,
-    time::{Duration, SystemTime, UNIX_EPOCH},
+    time::Duration,
 };
+
+#[cfg(not(target_family="wasm"))]
+use std::time::{SystemTime, UNIX_EPOCH};
+#[cfg(target_family="wasm")]
+use wasmtimer::std::{SystemTime, UNIX_EPOCH};
 
 use crate::{
     encoders::{


### PR DESCRIPTION
Currently wasm targets are not supported, as `std::time::SystemTime::now()` panics on wasm targets. This change adds support for wasm via the [`wasmtimer` crate](https://crates.io/crates/wasmtimer) crate for getting the current timestamp.

Note that also `gethostname` needs to be disabled for wasm.

Why [`wasmtimer`](https://crates.io/crates/wasmtimer) instead of [`web-time`](https://crates.io/crates/web-time)? `wasmtimer` also has support for functionality from `tokio::time` like `timeout`, which will come in handy when for example `mail-send` will support wasm and then both packages can share the same dependency.