### PR TITLE
fix: try to avoid lines longer than 78 characters

### DIFF
--- a/src/encoders/encode.rs
+++ b/src/encoders/encode.rs
@@ -44,7 +44,7 @@ pub fn get_encoding_type(input: &[u8], is_inline: bool, is_body: bool) -> Encodi
         {
             qp_len += 3;
         } else if ch == b'\n' {
-            if !needs_encoding && line_len > 997 {
+            if !needs_encoding && line_len > 77 {
                 needs_encoding = true;
             }
             if is_body {

--- a/src/mime.rs
+++ b/src/mime.rs
@@ -418,3 +418,33 @@ fn detect_encoding(input: &[u8], mut output: impl Write, is_body: bool) -> io::R
     }
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_detect_encoding() {
+        let mut output = Vec::new();
+        detect_encoding(b"a b c\r\n", &mut output, false).unwrap();
+        assert_eq!(output, b"Content-Transfer-Encoding: 7bit\r\n\r\na b c\r\n");
+
+        let mut output = Vec::new();
+        detect_encoding(
+            b"a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a\r\n",
+            &mut output,
+            false,
+        )
+        .unwrap();
+        assert_eq!(output, b"Content-Transfer-Encoding: 7bit\r\n\r\na a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a\r\n");
+
+        let mut output = Vec::new();
+        detect_encoding(
+            b"a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a\r\n",
+            &mut output,
+            false,
+        )
+        .unwrap();
+        assert_eq!(output, b"Content-Transfer-Encoding: quoted-printable\r\n\r\na a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a =\r\na=0D=0A");
+    }
+}


### PR DESCRIPTION
<https://www.rfc-editor.org/rfc/rfc5322#section-2.1.1> says lines MUST not exceed 998 characters,
but SHOULD not exceed 78 characters.

Closes https://github.com/stalwartlabs/mail-builder/issues/31