### PR TITLE
fix: add semicolon at the end of group addresses

### DIFF
--- a/src/headers/address.rs
+++ b/src/headers/address.rs
@@ -237,6 +237,8 @@ impl Header for GroupedAddresses<'_> {
             }
         }
 
+        output.write_all(b";")?;
+
         Ok(bytes_written)
     }
 }


### PR DESCRIPTION
Fixes #35