### PR TITLE
Do not split UTF-8 characters between "Q"-encoded-words

### DIFF
--- a/src/encoders/encode.rs
+++ b/src/encoders/encode.rs
@@ -6,7 +6,7 @@
 
 use std::io::{self, Write};
 
-use super::{base64::base64_encode_mime, quoted_printable::quoted_printable_encode};
+use super::{base64::base64_encode_mime, quoted_printable::inline_quoted_printable_encode};
 
 pub enum EncodingType {
     Base64,
@@ -89,9 +89,8 @@ pub fn rfc2047_encode(input: &str, mut output: impl Write) -> io::Result<usize> 
             } else {
                 output.write_all(b"\"=?us-ascii?Q?")?;
             }
-            let bytes_written =
-                quoted_printable_encode(input.as_bytes(), &mut output, true, false)?
-                    + if is_ascii { 19 } else { 14 };
+            let bytes_written = inline_quoted_printable_encode(input.as_bytes(), &mut output)?
+                + if is_ascii { 19 } else { 14 };
             output.write_all(b"?=\"")?;
             bytes_written
         }

--- a/src/headers/text.rs
+++ b/src/headers/text.rs
@@ -9,7 +9,7 @@ use std::borrow::Cow;
 use crate::encoders::{
     base64::base64_encode_mime,
     encode::{get_encoding_type, EncodingType},
-    quoted_printable::quoted_printable_encode,
+    quoted_printable::inline_quoted_printable_encode,
 };
 
 use super::Header;
@@ -63,7 +63,7 @@ impl Header for Text<'_> {
                     } else {
                         output.write_all(b"=?us-ascii?Q?")?;
                     }
-                    quoted_printable_encode(chunk, &mut output, true, false)?;
+                    inline_quoted_printable_encode(chunk, &mut output)?;
                     output.write_all(b"?=\r\n")?;
                 }
             }

--- a/src/mime.rs
+++ b/src/mime.rs
@@ -398,7 +398,7 @@ fn detect_encoding(input: &[u8], mut output: impl Write, is_body: bool) -> io::R
         }
         EncodingType::QuotedPrintable(_) => {
             output.write_all(b"Content-Transfer-Encoding: quoted-printable\r\n\r\n")?;
-            quoted_printable_encode(input, &mut output, false, is_body)?;
+            quoted_printable_encode(input, &mut output, is_body)?;
         }
         EncodingType::None => {
             output.write_all(b"Content-Transfer-Encoding: 7bit\r\n\r\n")?;


### PR DESCRIPTION
Partially addresses #40.

Multiple commits, don't squash.